### PR TITLE
Remove deprecated methods, code cleanup

### DIFF
--- a/library/src/main/java/com/pixplicity/sharp/Line.java
+++ b/library/src/main/java/com/pixplicity/sharp/Line.java
@@ -1,6 +1,0 @@
-package com.pixplicity.sharp;
-
-import android.graphics.RectF;
-
-public class Line extends RectF {
-}

--- a/library/src/main/java/com/pixplicity/sharp/SharpDrawable.java
+++ b/library/src/main/java/com/pixplicity/sharp/SharpDrawable.java
@@ -148,16 +148,19 @@ public class SharpDrawable extends PictureDrawable {
      * automatically redrawn, as the way in which the SharpDrawable is drawn may change without it
      * being informed. To manually redraw the cache, invoke {@link #resetCache()}.
      *
-     * @param caching
+     * @param caching boolean
      */
+    @SuppressWarnings("unused")
     public void setCaching(boolean caching) {
         mCaching = caching;
     }
 
+    @SuppressWarnings("unused")
     public void setCacheScale(float scale) {
         mCacheScale = scale;
     }
 
+    @SuppressWarnings("unused")
     public void resetCache() {
         if (!mCaching) {
             throw new IllegalStateException("Cache is not enabled");

--- a/library/src/main/java/com/pixplicity/sharp/SvgColors.java
+++ b/library/src/main/java/com/pixplicity/sharp/SvgColors.java
@@ -27,7 +27,7 @@ import java.util.HashMap;
 
 public class SvgColors {
 
-    private static HashMap<String, Integer> colors = new HashMap<String, Integer>();
+    private static HashMap<String, Integer> colors = new HashMap<>();
 
     public static Integer mapColor(String color) {
         return colors.get(color.toLowerCase());

--- a/library/src/main/java/com/pixplicity/sharp/SvgParseException.java
+++ b/library/src/main/java/com/pixplicity/sharp/SvgParseException.java
@@ -30,10 +30,12 @@ package com.pixplicity.sharp;
  */
 public class SvgParseException extends RuntimeException {
 
+    @SuppressWarnings("unused")
     public SvgParseException(String s) {
         super(s);
     }
 
+    @SuppressWarnings("unused")
     public SvgParseException(String s, Throwable throwable) {
         super(s, throwable);
     }


### PR DESCRIPTION
According to #23 deprecated methods was removed. 
I also did some code cleanup:
- there was unnecessary hidden2 value, mWhiteMode, 
- method angle had typos in param names, 
- unused private method getHexAttr, pathStyleHelper, toFloat
- p had assignments just before return
- there was redundant class Line that was replaced by RectF
