### PR TITLE
Transparent fill property from 'g' was not overriding inner elements …

### DIFF
--- a/library/src/main/java/com/pixplicity/sharp/Sharp.java
+++ b/library/src/main/java/com/pixplicity/sharp/Sharp.java
@@ -1240,6 +1240,7 @@ public abstract class Sharp {
 
         private Paint mFillPaint;
         private boolean mFillSet = false;
+        private int mFillColor;
         private Stack<Paint> mFillPaintStack = new Stack<>();
         private Stack<Boolean> mFillSetStack = new Stack<>();
 
@@ -1393,6 +1394,7 @@ public abstract class Sharp {
                 }
             } else {
                 if (mFillSet) {
+                    mFillPaint.setColor(mFillColor);
                     // If fill is set, inherit from parent
                     // optimization: return false if transparent
                     return mFillPaint.getColor() != Color.TRANSPARENT;
@@ -1794,6 +1796,9 @@ public abstract class Sharp {
                 doStroke(props, null);
 
                 mFillSet |= (props.getString("fill") != null);
+                if(mFillSet) {
+                    mFillColor = mFillPaint.getColor();
+                }
                 mStrokeSet |= (props.getString("stroke") != null);
 
                 SvgGroup group = new SvgGroup(id);


### PR DESCRIPTION
…fill properties.

Example (rect was painting Black color, although it has to be overriden by 'g' fill="none" and be transparent):
<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
  <g fill="none" fill-rule="evenodd">
    <rect width="32" height="32"/>
    <path ......."/>
  </g>
</svg>